### PR TITLE
Support for Lean language build errors

### DIFF
--- a/problem-matchers/lean.json
+++ b/problem-matchers/lean.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "lean",
+      "pattern": [
+        {
+          "regexp": "^(warning|error):\\s+(.*):(\\d+):(\\d+):\\s+(.*)$",
+          "severity": 1,
+          "file": 2,
+          "line": 3,
+          "column": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a file with support for [Lean](https://lean-lang.org) error message syntax.

We use the `problem-matcher-wrap` action in CI for projects in the Lean language, especially https://github.com/leanprover-community/mathlib4. [Lean changed its error message syntax a while back](https://github.com/leanprover-community/mathlib4/issues/12946), and so the nice error messages stopped appearing. With the new `lean` problem matcher regex added in this PR, everything should work again with the latest versions of Lean.

Example of the annotated output:

<img width="1078" alt="Screenshot 2025-04-23 at 13 26 32" src="https://github.com/user-attachments/assets/505ecfe7-5a4b-48bb-9faa-f1c781ab2c3a" />
<img width="1162" alt="Screenshot 2025-04-23 at 14 07 16" src="https://github.com/user-attachments/assets/5ecb7d90-3431-42ba-a23e-b3da5a354cf1" />

(Screenshots from https://github.com/leanprover-community/mathlib4/actions/runs/14617507898/job/41009027153).